### PR TITLE
fix: update contract address and action ID

### DIFF
--- a/src/WorldIDComponent.tsx
+++ b/src/WorldIDComponent.tsx
@@ -1,4 +1,5 @@
 import { defaultAbiCoder as abi } from "@ethersproject/abi";
+import { keccak256 } from "@ethersproject/solidity";
 import type { VerificationResponse } from "@worldcoin/id";
 import worldID from "@worldcoin/id";
 import React from "react";
@@ -24,8 +25,11 @@ export const WorldIDComponent = ({
   React.useEffect(() => {
     if (!worldID.isInitialized()) {
       worldID.init("world-id-container", {
-        actionId: CONTRACT_ADDRESS,
-        signal: abi.encode(["address"], [signal]),
+        actionId: abi.encode(
+          ["uint256"],
+          [BigInt(keccak256(["bytes"], [CONTRACT_ADDRESS])) >> BigInt(8)],
+        ),
+        signal,
       });
     }
     if (!worldID.isEnabled()) {

--- a/src/WorldIDComponent.tsx
+++ b/src/WorldIDComponent.tsx
@@ -5,6 +5,13 @@ import worldID from "@worldcoin/id";
 import React from "react";
 import { CONTRACT_ADDRESS } from "./const";
 
+const hashBytes = (input: string): string => {
+  return abi.encode(
+    ["uint256"],
+    [BigInt(keccak256(["bytes"], [input])) >> BigInt(8)],
+  );
+};
+
 export const WorldIDComponent = ({
   signal,
   setProof,
@@ -25,10 +32,7 @@ export const WorldIDComponent = ({
   React.useEffect(() => {
     if (!worldID.isInitialized()) {
       worldID.init("world-id-container", {
-        actionId: abi.encode(
-          ["uint256"],
-          [BigInt(keccak256(["bytes"], [CONTRACT_ADDRESS])) >> BigInt(8)],
-        ),
+        actionId: hashBytes(CONTRACT_ADDRESS),
         signal,
       });
     }

--- a/src/const.tsx
+++ b/src/const.tsx
@@ -16,7 +16,7 @@ export const provider = new WalletConnectProvider({
 
 export const CONTRACT_ADDRESS =
   process.env.WLD_CONTRACT_ADDRESS || // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
-  "0x330C8452C879506f313D1565702560435b0fee4C";
+  "0x32D59776E91fdb3F377755e12cEC05d9067c2B4F";
 
 export const CONTRACT_ABI = [
   // Function to claim the airdrop


### PR DESCRIPTION
- Updates base address to newly deployed contract.
- Action ID is now the hashed bytes of the deployed contract address (of course users can use a different action ID, provided it matches their own smart contract).

